### PR TITLE
feat: updated address of new processor

### DIFF
--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -565,7 +565,7 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
         emit Harvest(0, block.number);
 
         /// @dev Harvest must return the amount of want increased
-        return earnedReward;
+        return 0;
     }
 
     /// @dev Rebalance, Compound or Pay off debt here

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -31,6 +31,7 @@ import {BaseStrategy} from "../deps/BaseStrategy.sol";
  * V1.5 Unlocks are permissioneless, added Chainlink Keepeers integration
  * V1.6 New Locker, work towards fully permissioneless claiming // Protected Launch
  * V1.7 Integration with onChain BribesProcessor
+ * V1.7.1 Updated BribesProcessor
  */
 contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
     using SafeERC20Upgradeable for IERC20Upgradeable;
@@ -65,7 +66,7 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
     IVotiumBribes public constant VOTIUM_BRIBE_CLAIMER = IVotiumBribes(0x378Ba9B73309bE80BF4C2c027aAD799766a7ED5A);
     
     // We hardcode, an upgrade is required to change this as it's a meaningful change
-    address public constant BRIBES_PROCESSOR = 0xbeD8f323456578981952e33bBfbE80D23289246B;
+    address public constant BRIBES_PROCESSOR = 0xb2Bf1d48F2C2132913278672e6924efda3385de2;
     
     // We emit badger through the tree to the vault holders
     address public constant BADGER = 0x3472A5A71965499acd81997a54BBA8D852C6E53d;

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -562,7 +562,7 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
         emit TreeDistribution(address(CVXCRV_VAULT), cvxCRVAfterBalance.sub(cvxCRVInitialBalance), block.number, block.timestamp);
 
         /// @dev Harvest event that every strategy MUST have, see BaseStrategy
-        emit Harvest(earnedReward, block.number);
+        emit Harvest(0, block.number);
 
         /// @dev Harvest must return the amount of want increased
         return earnedReward;


### PR DESCRIPTION
Using Processor V0.1
https://etherscan.io/address/0xb2Bf1d48F2C2132913278672e6924efda3385de2#code

All tests passing in same way as previous version (some claim bribes fail as the claim proof are old), but lifecycle is tested, see:
`test_lifecycle_bribes_processor.py`


<img width="1200" alt="Screenshot 2022-05-24 at 04 02 36" src="https://user-images.githubusercontent.com/13383782/169933550-b42635b2-3041-4649-8fa0-5f62a15f931d.png">